### PR TITLE
支持webhook

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,18 @@
+# Caddyfile 用以配置webhook的反向代理
+# 更改域名为自己的域名并配置好Dns解析
+# 更改route 后的后缀为每个Docker容器中的url-path 并更改 reverse_proxy 后面的端口号为映射的端口号
+
+https://hook.examlple.xyz {
+        encode gzip
+        tls internal
+        route /test {
+                reverse_proxy http://127.0.0.1:9968
+        }
+        route /good {
+                reverse_proxy http://127.0.0.1:9969
+        }
+}
+<<<<<<< HEAD
+=======
+
+>>>>>>> 5fe7213 (支持webhook模式并添加docker-compose构建)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+services:
+
+    tgbot:
+        container_name: tgbot
+        image: taosky/telegram-search-bot:v2
+        restart: always
+        volumes:
+            - ./bot.db:/app/bot.db
+        ports:
+            - 5006:5006
+            - 9968:9968
+        environment:
+            - BOT_MODE=webhook
+            - URL_PATH=test
+            - HOOK_URL=https://hook.example.xyz/test
+            - BOT_TOKEN=yourtoken
+    caddy:
+        container_name: caddy
+        image: caddy:2-alpine
+        restart: unless-stopped
+        volumes:
+            - ./Caddyfile:/etc/caddy/Caddyfile
+        network_mode: "host"
+<<<<<<< HEAD
+=======
+
+>>>>>>> 5fe7213 (支持webhook模式并添加docker-compose构建)

--- a/robot.py
+++ b/robot.py
@@ -6,7 +6,7 @@ from user_handlers import bot_help, bot_start, chatid_get, db_file_get, msg_sear
 from user_jobs.commands_set import set_bot_commands
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                     level=logging.DEBUG)
+                    level=logging.DEBUG)
 
 bot_token = os.getenv('BOT_TOKEN')
 
@@ -26,7 +26,16 @@ dispatcher.add_handler(db_file_get.handler)
 dispatcher.add_handler(msg_search.handler)
 dispatcher.add_handler(msg_store.handler)
 
-if __name__ == '__main__':        
-    # Polling mode
-    updater.start_polling()
+if __name__ == '__main__':
+    # Select mode
+    if os.getenv("BOT_MODE") == "webhook":
+        url_path = os.getenv("URL_PATH")
+        hook_url = os.getenv("HOOK_URL")
+        updater.start_webhook(listen='0.0.0.0',
+                              port=9968,
+                              url_path=url_path,
+                              webhook_url=hook_url)
+    else:
+        updater.start_polling()
     updater.idle()
+


### PR DESCRIPTION
## 新增变量 `BOT_MODE` `URL_PATH` `HOOK_URL` 用以支持webhook模式
* `BOT_MODE` 设置为webhook则启用webhook模式
* `URL_PATH` `HOOK_URL` 分别为webhook模式的相关参数，仅当启用webhook模式后生效  [参考wiki](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Webhooks)
* 考虑到可以映射端口，因此固定监听端口为*9968*

## 新增doker-compose构建
由于webhook需要配置反向代理，因此新增了一个docker-compose构建的方法，可以帮助快速构建多个容器并和caddy配合。这样也不影响常规poll模式

vps测试了一下没什么问题