### PR TITLE
fix: 尝试修复start错误 (fix #57)

### DIFF
--- a/user_handlers/chat_start.py
+++ b/user_handlers/chat_start.py
@@ -1,4 +1,6 @@
 from telegram.ext import CommandHandler
+import telegram.error
+
 from database import Chat, DBSession
 from utils import check_control_permission, is_userbot_mode, read_userbot_admin_id
 
@@ -37,8 +39,16 @@ def start(update, context):
     # 正常模式直接在对应群聊中使用命令
     chat_id = update.effective_chat.id
     chat_title = update.message.chat.title
-    chat_member = context.bot.get_chat_member(
-        chat_id=chat_id, user_id=from_user_id)
+    
+    # 对成员过多的群组非管理员可能无法读取成员信息
+    try:
+        chat_member = context.bot.get_chat_member(
+            chat_id=chat_id, user_id=from_user_id)
+    except telegram.error.BadRequest:
+        context.bot.send_message(chat_id=update.effective_chat.id, 
+            text='读取群成员信息出错 (Telegram对大群的限制), 授予管理员后再试')
+        return
+    
     # Check control permission
     if check_control_permission(from_user_id) is True:
         pass


### PR DESCRIPTION
在成员数量过大的群组中（千人以上？），非管理员bot无法获取群成员信息，get_chat_member会报错，添加了一个出错处理，发送提示消息。