### PR TITLE
fix: answer_inline_query cached response to unauthorized user

### DIFF
--- a/user_handlers/msg_search.py
+++ b/user_handlers/msg_search.py
@@ -200,7 +200,7 @@ def inline_caps(update, context):
             )
         )
     context.bot.answer_inline_query(
-        update.inline_query.id, results, cache_time=CACHE_TIME)
+        update.inline_query.id, results, cache_time=CACHE_TIME, is_personal=True)
 
 
 handler = InlineQueryHandler(inline_caps)

--- a/user_handlers/msg_search.py
+++ b/user_handlers/msg_search.py
@@ -160,7 +160,7 @@ def inline_caps(update, context):
             )
             num += 1
         context.bot.answer_inline_query(
-            update.inline_query.id, results, cache_time=CACHE_TIME)
+            update.inline_query.id, results, cache_time=CACHE_TIME, is_personal=True)
         return
 
     messages, count = search_messages(user, keywords, page, filter_chats)


### PR DESCRIPTION
based on the Telegram Bot API docs https://core.telegram.org/bots/api#answerinlinequery

> By default, results may be returned to any user who sends the same query.

unauthorized user may able to see the result after an authorized user search because of cache.